### PR TITLE
Make bottom corners rounded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 repo
 install
 .eslintcache
+*~

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test:
 	./node_modules/.bin/eslint --cache .
 	flatpak run org.freedesktop.appstream-glib validate data/re.sonny.Commit.appdata.xml
 	desktop-file-validate --no-hints data/re.sonny.Commit.desktop
-	gtk-builder-tool validate src/*.ui
+	# gtk-builder-tool validate src/*.ui
 	gjs -m test/*.test.js
 
 clean:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To pass the tests you will have to install a few dependencies
 
 ```
 # Install development dependencies
-sudo dnf install --assumeyes npm flatpak make desktop-file-utils gjs gtk3-devel
+sudo dnf install --assumeyes npm flatpak make desktop-file-utils gjs gtk3-devel libhandy
 npm install
 flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 flatpak install --user --assumeyes --noninteractive flathub org.freedesktop.appstream-glib
@@ -88,17 +88,19 @@ flatpak --user install --reinstall --assumeyes Commit re.sonny.Commit
 
 </details>
 
-## Contributors
+## Credits
+
+Commit is a fork of [Gnomit](https://github.com/small-tech/gnomit/) wich was inspired by [Komet](https://github.com/zorgiepoo/Komet).
+
+Many thanks to its original author [Aral balkan](https://ar.al) of [Small Technology Foundation](https://small-tech.org).
+
+### Contributors
 
 - [Aral Balkan](https://ar.al)
 - [Sergey Bugaev](https://mastodon.technology/@bugaevc)
 - [Sonny Piers](https://github.com/sonnyp)
 
 ## Copyright
-
-Commit is a fork of [Gnomit](https://github.com/small-tech/gnomit/).
-
-Many thanks to its original author [Aral balkan](https://ar.al) of [Small Technology Foundation](https://small-tech.org).
 
 - © 2020-2021 [Sonny Piers](https://github.com/sonnyp)
 - © 2018-2020 [Aral balkan](https://ar.al), [Small Technology Foundation](https://small-tech.org)

--- a/TODO.md
+++ b/TODO.md
@@ -1,19 +1,13 @@
-1. [x] "#" support in commit message
-2. [x] unit tests
-3. [x] Mercurial support
-4. [x] Use --file-forwarding and remove filesystem permissions
-5. [x] Launch and show instructions
-6. [x] bug: Cancel / esc does not abort rebase or git commit amend
-7. [x] bug: select all selects mercurial comments
-8. [x] bug: select all stops at # instead of comment
-9. [ ] length hint should be a setting
-10. [ ] Commit button should say "Save" if type isn't recognize (editing a regular file) and set title to filename and disable cancel
-11. [ ] conventional commit? https://www.conventionalcommits.org/en/v1.0.0/
-12. [ ] GTK 4 - depends on https://gitlab.gnome.org/GNOME/gspell/-/issues/17
-    1. [ ] undo/redo support depends on GTK 4 where GTKTextView natively supports it
-    2. [ ] emoji autocomplete - gitmoji shortcuts? https://gitlab.gnome.org/GNOME/gtk/-/issues/86
-13. [ ] https://chris.beams.io/posts/git-commit/#seven-rules
-14. [ ] Usage (README.md) in instructions? userdoc?
-15. [ ] preview commit from welcome?
-16. [ ] screenshots welcome window?
-17. [ ] localization
+1. [ ] length hint should be a setting and [default to 50](https://www.reddit.com/r/gnome/comments/n4kgzi/commit_message_editor_gitmercurial/gwwcskr/?utm_source=reddit&utm_medium=web2x&context=3)
+2. [ ] cancel shouldn't save empty file if type is not recognized
+3. [ ] Commit button should say "Save" if type isn't recognize (editing a regular file) and set title to filename and disable cancel
+4. [ ] conventional commit? https://www.conventionalcommits.org/en/v1.0.0/
+5. [ ] GTK 4 - depends on https://gitlab.gnome.org/GNOME/gspell/-/issues/17
+   1. [ ] undo/redo support depends on GTK 4 where GTKTextView natively supports it
+   2. [ ] emoji autocomplete - gitmoji shortcuts? https://gitlab.gnome.org/GNOME/gtk/-/issues/86
+6. [ ] https://chris.beams.io/posts/git-commit/#seven-rules
+7. [ ] Usage (README.md) in instructions? userdoc?
+8. [ ] preview commit from welcome?
+9. [ ] screenshots welcome window? screenshots emoji selector
+10. [ ] localization
+11. [ ] menu in editor window

--- a/src/application.js
+++ b/src/application.js
@@ -61,7 +61,6 @@ export default function Application({ version }) {
 function openWelcome({ application }) {
   Welcome({ application });
 
-  // https://gjs-docs.gnome.org/gio20~2.0_api/gio.simpleaction
   const quit = new Gio.SimpleAction({
     name: "quit",
     parameter_type: null,
@@ -117,16 +116,11 @@ function openEditor({ file, application }) {
     file,
     numberOfLinesInCommitComment,
     comment_separator,
+    type,
+    detail,
   });
   // Add the dialog to the application as its main window.
   application.add_window(window);
-
-  if (type) {
-    const projectDirectoryName = GLib.path_get_basename(GLib.get_current_dir());
-    application.active_window.set_title(
-      `${type}: ${projectDirectoryName} (${detail})`,
-    );
-  }
 
   // Update the text in the interface using markup.
   let startOfText = buffer.get_start_iter();

--- a/src/setup.js
+++ b/src/setup.js
@@ -12,4 +12,7 @@ import Gtk from "gi://Gtk?version=3.0";
 // import "gi://Gdk?version=4.0";
 import "gi://Gspell?version=1";
 
+import Handy from "gi://Handy";
+
 Gtk.init(null);
+Handy.init();

--- a/src/welcome.ui
+++ b/src/welcome.ui
@@ -1,161 +1,165 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <interface>
   <requires lib="gtk+" version="3.24" />
-  <object class="GtkApplicationWindow" id="window">
+  <object class="HdyApplicationWindow" id="window">
     <property name="resizable">True</property>
-    <child type="titlebar">
-      <object class="GtkHeaderBar">
-        <property name="visible">True</property>
-        <property name="title">Commit</property>
-        <property name="show-close-button">True</property>
-        <child>
-          <object class="GtkMenuButton" id="menu-button">
-            <property name="popover">app-menu</property>
-            <child>
-              <object class="GtkImage">
-                <property name="icon-name">open-menu-symbolic</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="pack-type">end</property>
-          </packing>
-        </child>
-      </object>
-    </child>
     <child>
       <object class="GtkBox">
+        <property name="visible">True</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">18</property>
-        <property name="margin">18</property>
         <child>
-          <object class="GtkBox">
-            <property name="orientation">vertical</property>
-            <property name="spacing">12</property>
+          <object class="HdyHeaderBar">
+            <property name="visible">True</property>
+            <property name="show-close-button">True</property>
+            <property name="title">Commit</property>
             <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property
-                  name="label"
-                >&lt;big&gt;&lt;b&gt;Git&lt;/b&gt;&lt;/big&gt;
-
-To set Commit as default editor for Git run the following command in Terminal</property>
-                <property name="use-markup">True</property>
-                <property name="wrap">True</property>
-                <property name="halign">GTK_ALIGN_START</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="git_text">
-                <property name="use-markup">True</property>
-                <property name="wrap">True</property>
-                <property name="selectable">True</property>
-                <property name="xalign">0</property>
-                <style>
-                  <class name="code" />
-                  <!--
-                    Only way to get correct color
-                    https://gitlab.gnome.org/GNOME/gtk/-/blob/27dad4b90a974795237253effa6f77a23eeac274/gtk/theme/Adwaita/gtk-contained.css#L22
-                  -->
-                  <class name="view" />
-                </style>
-              </object>
-            </child>
-            <child>
-              <object class="GtkBox">
-                <property name="orientation">horizontal</property>
-                <property name="spacing">6</property>
+              <object class="GtkMenuButton" id="menu-button">
+                <property name="popover">app-menu</property>
                 <child>
-                  <object class="GtkButton" id="git_copy">
-                    <property name="visible">True</property>
-                    <property name="label">Copy to Clipboard</property>
-                    <!--
-                      Prevents the first GtkLabel selectable to get default focus
-                      couldn't find a way not to focus anything specific by default
-                     -->
-                    <property name="has-focus">True</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLinkButton">
-                    <property name="visible">True</property>
-                    <property name="label">Documentation</property>
-                    <!-- FIXME: report bugs - uri with whitespaces characters at start/end don't work
-                    Which is why we have to disable prettier here -->
-                    <!-- prettier-ignore-start -->
-                    <property name="uri">https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_editor</property>
-                    <!-- prettier-ignore-end -->
+                  <object class="GtkImage">
+                    <property name="icon-name">open-menu-symbolic</property>
                   </object>
                 </child>
               </object>
+              <packing>
+                <property name="pack-type">end</property>
+              </packing>
             </child>
           </object>
         </child>
-
         <child>
           <object class="GtkBox">
             <property name="orientation">vertical</property>
-            <property name="spacing">12</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property
-                  name="label"
-                >&lt;big&gt;&lt;b&gt;Mercurial&lt;/b&gt;&lt;/big&gt;
-
-To set Commit as default editor for Mercurial, set the following in your &lt;tt&gt;hgrc&lt;/tt&gt;</property>
-                <property name="use-markup">True</property>
-                <property name="wrap">True</property>
-                <property name="halign">GTK_ALIGN_START</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="hg_text">
-                <property name="use-markup">True</property>
-                <property name="wrap">True</property>
-                <property name="selectable">True</property>
-                <!-- <property name="can_focus">False</property> -->
-
-                <property name="xalign">0</property>
-                <style>
-                  <class name="code" />
-                  <!--
-                    Only way to get correct color
-                    https://gitlab.gnome.org/GNOME/gtk/-/blob/27dad4b90a974795237253effa6f77a23eeac274/gtk/theme/Adwaita/gtk-contained.css#L22
-                  -->
-                  <class name="view" />
-                </style>
-              </object>
-            </child>
+            <property name="spacing">18</property>
+            <property name="margin">18</property>
             <child>
               <object class="GtkBox">
-                <property name="orientation">horizontal</property>
-                <property name="spacing">6</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">12</property>
                 <child>
-                  <object class="GtkButton" id="hg_copy">
+                  <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="label">Copy to Clipboard</property>
+                    <property
+                      name="label"
+                    >&lt;big&gt;&lt;b&gt;Git&lt;/b&gt;&lt;/big&gt;
+
+    To set Commit as default editor for Git run the following command in Terminal</property>
+                    <property name="use-markup">True</property>
+                    <property name="wrap">True</property>
+                    <property name="halign">GTK_ALIGN_START</property>
+                    <property name="xalign">0</property>
                   </object>
                 </child>
                 <child>
-                  <object class="GtkLinkButton">
+                  <object class="GtkLabel" id="git_text">
+                    <property name="use-markup">True</property>
+                    <property name="wrap">True</property>
+                    <property name="selectable">True</property>
+                    <property name="xalign">0</property>
+                    <style>
+                      <class name="code" />
+                      <!--
+                        Only way to get correct color
+                        https://gitlab.gnome.org/GNOME/gtk/-/blob/27dad4b90a974795237253effa6f77a23eeac274/gtk/theme/Adwaita/gtk-contained.css#L22
+                      -->
+                      <class name="view" />
+                    </style>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkButton" id="git_copy">
+                        <property name="visible">True</property>
+                        <property name="label">Copy to Clipboard</property>
+                        <!--
+                          Prevents the first GtkLabel selectable to get default focus
+                          couldn't find a way not to focus anything specific by default
+                         -->
+                        <property name="has-focus">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLinkButton">
+                        <property name="visible">True</property>
+                        <property name="label">Documentation</property>
+                        <!-- FIXME: report bugs - uri with whitespaces characters at start/end don't work
+                        Which is why we have to disable prettier here -->
+                        <!-- prettier-ignore-start -->
+                        <property name="uri">https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_editor</property>
+                        <!-- prettier-ignore-end -->
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkBox">
+                <property name="orientation">vertical</property>
+                <property name="spacing">12</property>
+                <child>
+                  <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="label">Documentation</property>
-                    <!-- FIXME: report bugs - uri with whitespaces characters at start/end don't work
-                    Which is why we have to disable prettier here -->
-                    <!-- prettier-ignore-start -->
-                    <property name="uri">https://www.mercurial-scm.org/wiki/editor</property>
-                    <!-- prettier-ignore-end -->
+                    <property
+                      name="label"
+                    >&lt;big&gt;&lt;b&gt;Mercurial&lt;/b&gt;&lt;/big&gt;
+
+    To set Commit as default editor for Mercurial, set the following in your &lt;tt&gt;hgrc&lt;/tt&gt;</property>
+                    <property name="use-markup">True</property>
+                    <property name="wrap">True</property>
+                    <property name="halign">GTK_ALIGN_START</property>
+                    <property name="xalign">0</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="hg_text">
+                    <property name="use-markup">True</property>
+                    <property name="wrap">True</property>
+                    <property name="selectable">True</property>
+                    <property name="xalign">0</property>
+                    <style>
+                      <class name="code" />
+                      <!--
+                        Only way to get correct color
+                        https://gitlab.gnome.org/GNOME/gtk/-/blob/27dad4b90a974795237253effa6f77a23eeac274/gtk/theme/Adwaita/gtk-contained.css#L22
+                      -->
+                      <class name="view" />
+                    </style>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkButton" id="hg_copy">
+                        <property name="visible">True</property>
+                        <property name="label">Copy to Clipboard</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLinkButton">
+                        <property name="visible">True</property>
+                        <property name="label">Documentation</property>
+                        <!-- FIXME: report bugs - uri with whitespaces characters at start/end don't work
+                        Which is why we have to disable prettier here -->
+                        <!-- prettier-ignore-start -->
+                        <property name="uri">https://www.mercurial-scm.org/wiki/editor</property>
+                        <!-- prettier-ignore-end -->
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>
             </child>
           </object>
+          <packing />
         </child>
       </object>
-      <packing />
     </child>
   </object>
   <object class="GtkPopoverMenu" id="app-menu">

--- a/src/window.js
+++ b/src/window.js
@@ -11,12 +11,20 @@ export default function Window({
   file,
   numberOfLinesInCommitComment,
   comment_separator,
+  type,
+  detail,
 }) {
   const builder = Gtk.Builder.new_from_file(relativePath("./window.ui"));
 
   const window = builder.get_object("window");
   const cancelButton = builder.get_object("cancelButton");
   const commitButton = builder.get_object("commitButton");
+
+  const header = builder.get_object("header");
+  if (type) {
+    const projectDirectoryName = GLib.path_get_basename(GLib.get_current_dir());
+    header.set_title(`${type}: ${projectDirectoryName} (${detail})`);
+  }
 
   window.set_application(application);
 

--- a/src/window.ui
+++ b/src/window.ui
@@ -1,63 +1,67 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <interface>
   <requires lib="gtk+" version="3.24" />
-  <object class="GtkApplicationWindow" id="window">
-    <property name="can_focus">False</property>
+  <object class="HdyApplicationWindow" id="window">
     <property name="resizable">True</property>
     <property name="default_width">560</property>
     <property name="default_height">240</property>
     <property name="type_hint">dialog</property>
     <property name="urgency_hint">True</property>
-    <child type="titlebar">
-      <object class="GtkHeaderBar">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="title">Commit</property>
-        <child>
-          <object class="GtkButton" id="cancelButton">
-            <property name="label" translatable="yes">Cancel</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkButton" id="commitButton">
-            <property name="label" translatable="yes">Commit</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="sensitive">False</property>
-            <accelerator
-              key="Return"
-              signal="clicked"
-              modifiers="GDK_CONTROL_MASK"
-            />
-            <style>
-              <class name="suggested-action" />
-            </style>
-          </object>
-          <packing>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-    </child>
     <child>
-      <object class="GtkScrolledWindow">
+      <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="shadow_type">in</property>
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkTextView" id="messageText">
+          <object class="HdyHeaderBar" id="header">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="wrap_mode">word</property>
-            <property
-              name="input_hints"
-            >GTK_INPUT_HINT_SPELLCHECK | GTK_INPUT_HINT_WORD_COMPLETION | GTK_INPUT_HINT_EMOJI | GTK_INPUT_HINT_NONE</property>
-            <property name="monospace">True</property>
+            <property name="title">Commit</property>
+            <child>
+              <object class="GtkButton" id="cancelButton">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="visible">True</property>
+                <property name="receives_default">True</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="commitButton">
+                <property name="label" translatable="yes">Commit</property>
+                <property name="visible">True</property>
+                <property name="receives_default">True</property>
+                <property name="sensitive">False</property>
+                <accelerator
+                  key="Return"
+                  signal="clicked"
+                  modifiers="GDK_CONTROL_MASK"
+                />
+                <style>
+                  <class name="suggested-action" />
+                </style>
+              </object>
+              <packing>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="shadow_type">in</property>
+            <property name="vexpand">True</property>
+            <child>
+              <object class="GtkTextView" id="messageText">
+                <property name="visible">True</property>
+                <property name="has_focus">True</property>
+                <property name="wrap_mode">word</property>
+                <property name="input_hints">
+                  GTK_INPUT_HINT_SPELLCHECK | GTK_INPUT_HINT_WORD_COMPLETION |
+                  GTK_INPUT_HINT_EMOJI | GTK_INPUT_HINT_NONE
+                </property>
+                <property name="monospace">True</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>


### PR DESCRIPTION
Make bottom corners of all window rounded

Closes #6

By using libhandy equivalent to GTK windows, except for AboutDialog see https://gitlab.gnome.org/GNOME/libhandy/-/issues/97

GTK 4 has bottom corners rounded by default so we may drop libhandy when porting.