### PR TITLE
Fix text escaping for markup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1274,9 +1274,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "node_modules/human-signals": {
@@ -3772,9 +3772,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "human-signals": {

--- a/src/application.js
+++ b/src/application.js
@@ -86,11 +86,8 @@ function openEditor({ file, application }) {
 
   commitMessage = ByteArray.toString(commitMessage);
 
-  // Escape tag start/end as we will be using markup to populate the buffer.
-  // (Otherwise, rebase -i commit messages fail, as they contain the strings
-  // <commit>, <label>, etc.
-  commitMessage = commitMessage.replace(/</g, "&lt;");
-  commitMessage = commitMessage.replace(/>/g, "&gt;");
+  // Escape text as we will be using markup to populate the buffer.
+  commitMessage = GLib.markup_escape_text(commitMessage, -1);
 
   const type = getType(filePath);
   // This should not happen.


### PR DESCRIPTION
Fixes #10

We use Pango markup for styling, XML characters have to be properly escaped. The character "&" was not escaped properly.