### PR TITLE
Only highlight text overflow on commit messages

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -11,6 +11,7 @@ export default function Editor({
   commitButton,
   numberOfLinesInCommitComment,
   comment_separator,
+  type,
 }) {
   let lastActionWasSelectAll;
 
@@ -30,37 +31,12 @@ export default function Editor({
   const highlightBackgroundTag = Gtk.TextTag.new(HIGHLIGHT_BACKGROUND_TAG_NAME);
   buffer.tag_table.add(highlightBackgroundTag);
   function setHighlightColour() {
-    // Set the overflow text background highlight colour based on the
-    // colour of the foreground text.
-
-    // Colour shade guide for Minty Rose: https://www.color-hex.com/color/ffe4e1
-    const darkForegroundHighlightColour = "#ffe4e1"; // minty rose
-    const lightForegroundHighlightColour = "#4c4443"; // darker shade of minty rose
-    let highlightColour;
-    const fontColour = gSpellTextView
-      .get_view()
-      .get_style_context()
-      .get_color(Gtk.StateFlags.NORMAL);
-
-    // Luma calculation courtesy: https://stackoverflow.com/a/12043228
-    const luma =
-      0.2126 * fontColour.red +
-      0.7152 * fontColour.green +
-      0.0722 * fontColour.blue; // ITU-R BT.709
-
-    // As get_color() returns r/g/b values between 0 and 1, the luma calculation will
-    // return values between 0 and 1 also.
-    if (luma > 0.5) {
-      // The foreground is light, use darker shade of original highlight colour.
-      highlightColour = lightForegroundHighlightColour;
-    } else {
-      // The foreground is dark, use original highlight colour.
-      highlightColour = darkForegroundHighlightColour;
-    }
-    highlightBackgroundTag.background = highlightColour;
+    highlightBackgroundTag.background = getHighlightColour(gSpellTextView);
   }
 
   function highlightText() {
+    if (!['commit', 'merge', 'hg'].includes(type)) return
+
     // Check first line length and highlight characters beyond the limit.
     const text = buffer.text;
     const lines = text.split("\n");
@@ -199,4 +175,36 @@ export default function Editor({
 // Method courtesy: https://stackoverflow.com/questions/51396490/getting-a-string-length-that-contains-unicode-character-exceeding-0xffff#comment89813733_51396686
 function unicodeLength(str) {
   return [...str].length;
+}
+
+function getHighlightColour(gSpellTextView) {
+  // Get the overflow text background highlight colour based on the
+  // colour of the foreground text.
+
+  // Colour shade guide for Minty Rose: https://www.color-hex.com/color/ffe4e1
+  const darkForegroundHighlightColour = "#ffe4e1"; // minty rose
+  const lightForegroundHighlightColour = "#4c4443"; // darker shade of minty rose
+  let highlightColour;
+  const fontColour = gSpellTextView
+    .get_view()
+    .get_style_context()
+    .get_color(Gtk.StateFlags.NORMAL);
+
+  // Luma calculation courtesy: https://stackoverflow.com/a/12043228
+  const luma =
+    0.2126 * fontColour.red +
+    0.7152 * fontColour.green +
+    0.0722 * fontColour.blue; // ITU-R BT.709
+
+  // As get_color() returns r/g/b values between 0 and 1, the luma calculation will
+  // return values between 0 and 1 also.
+  if (luma > 0.5) {
+    // The foreground is light, use darker shade of original highlight colour.
+    highlightColour = lightForegroundHighlightColour;
+  } else {
+    // The foreground is dark, use original highlight colour.
+    highlightColour = darkForegroundHighlightColour;
+  }
+
+  return highlightColour;
 }

--- a/src/window.js
+++ b/src/window.js
@@ -53,6 +53,7 @@ export default function Window({
     commitButton,
     numberOfLinesInCommitComment,
     comment_separator,
+    type,
   });
 
   window.connect("style-updated", () => {

--- a/test/rebase-merge/git-rebase-todo
+++ b/test/rebase-merge/git-rebase-todo
@@ -1,6 +1,7 @@
-pick a7ad46b Latest changes
+pick f353b3a this commit message is too long please fix me! wow so long commit message! damn!
+pick 688174c Im ok
 
-# Rebase df3db1d..a7ad46b onto df3db1d (1 command)
+# Rebase d44e355..688174c onto d44e355 (2 commands)
 #
 # Commands:
 # p, pick <commit> = use commit
@@ -9,6 +10,7 @@ pick a7ad46b Latest changes
 # s, squash <commit> = use commit, but meld into previous commit
 # f, fixup <commit> = like "squash", but discard this commit's log message
 # x, exec <command> = run command (the rest of the line) using shell
+# b, break = stop here (continue rebase later with 'git rebase --continue')
 # d, drop <commit> = remove commit
 # l, label <label> = label current HEAD with a name
 # t, reset <label> = reset HEAD to a label
@@ -21,7 +23,5 @@ pick a7ad46b Latest changes
 #
 # If you remove a line here THAT COMMIT WILL BE LOST.
 #
-#	However, if you remove everything, the rebase will be aborted.
+# However, if you remove everything, the rebase will be aborted.
 #
-#
-# Note that empty commits are commented out

--- a/test/scm.test.js
+++ b/test/scm.test.js
@@ -139,16 +139,17 @@ is(
 
 is(
   parse(readTest("rebase-merge/git-rebase-todo"), "rebase").body,
-  `pick a7ad46b Latest changes`,
+  `pick f353b3a this commit message is too long please fix me! wow so long commit message! damn!
+pick 688174c Im ok`,
 );
 is(
   parse(readTest("rebase-merge/git-rebase-todo"), "rebase").detail,
-  `df3db1d..a7ad46b → df3db1d`,
+  `d44e355..688174c → d44e355`,
 );
 is(
   parse(readTest("rebase-merge/git-rebase-todo"), "rebase").comment,
   `
-# Rebase df3db1d..a7ad46b onto df3db1d (1 command)
+# Rebase d44e355..688174c onto d44e355 (2 commands)
 #
 # Commands:
 # p, pick <commit> = use commit
@@ -157,6 +158,7 @@ is(
 # s, squash <commit> = use commit, but meld into previous commit
 # f, fixup <commit> = like "squash", but discard this commit's log message
 # x, exec <command> = run command (the rest of the line) using shell
+# b, break = stop here (continue rebase later with 'git rebase --continue')
 # d, drop <commit> = remove commit
 # l, label <label> = label current HEAD with a name
 # t, reset <label> = reset HEAD to a label
@@ -169,11 +171,9 @@ is(
 #
 # If you remove a line here THAT COMMIT WILL BE LOST.
 #
-#	However, if you remove everything, the rebase will be aborted.
+# However, if you remove everything, the rebase will be aborted.
 #
-#
-# Note that empty commits are commented out`,
-);
+`);
 
 is(parse(readTest("TAG_EDITMSG"), "tag").body, ``);
 is(parse(readTest("TAG_EDITMSG"), "tag").detail, `1.0.0`);


### PR DESCRIPTION
It would make sense on rebase as well but is more work.
See https://github.com/sonnyp/Commit/issues/13