### PR TITLE
flatpak: Update runtime to 42

### DIFF
--- a/re.sonny.Commit.json
+++ b/re.sonny.Commit.json
@@ -1,7 +1,7 @@
 {
   "app-id": "re.sonny.Commit",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "41",
+  "runtime-version": "42",
   "sdk": "org.gnome.Sdk",
   "command": "re.sonny.Commit",
   "finish-args": [
@@ -11,75 +11,7 @@
     "--require-version=1.1.2",
     "--device=dri"
   ],
-  "cleanup": [
-    "/include",
-    "/lib/pkgconfig",
-    "/man",
-    "/share/doc",
-    "/share/gtk-doc",
-    "/share/man",
-    "/share/pkgconfig",
-    "*.la",
-    "*.a"
-  ],
   "modules": [
-    {
-      "name": "libadwaita",
-      "buildsystem": "meson",
-      "config-opts": ["-Dvapi=false", "-Dexamples=false", "-Dtests=false"],
-      "cleanup": ["/include", "/lib/pkgconfig"],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://download.gnome.org/sources/libadwaita/1.0/libadwaita-1.0.0.alpha.4.tar.xz",
-          "sha256": "d3000ff56282947f5c51bbb3f9b7e7edb24d212b107bc009ba163464edbb8d7c"
-        }
-      ],
-      "modules": [
-        {
-          "name": "libsass",
-          "sources": [
-            {
-              "type": "archive",
-              "url": "https://github.com/sass/libsass/archive/3.6.4.tar.gz",
-              "sha256": "f9484d9a6df60576e791566eab2f757a97fd414fce01dd41fc0a693ea5db2889"
-            },
-            {
-              "type": "script",
-              "dest-filename": "autogen.sh",
-              "commands": ["autoreconf -si"]
-            }
-          ]
-        },
-        {
-          "name": "sassc",
-          "sources": [
-            {
-              "type": "archive",
-              "url": "https://github.com/sass/sassc/archive/3.6.1.tar.gz",
-              "sha256": "8cee391c49a102b4464f86fc40c4ceac3a2ada52a89c4c933d8348e3e4542a60"
-            },
-            {
-              "type": "script",
-              "dest-filename": "autogen.sh",
-              "commands": ["autoreconf -si"]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "gtksourceview",
-      "buildsystem": "meson",
-      "config-opts": ["-Dtests=false", "-Dexamples=false", "-Dvapi=false"],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://download.gnome.org/sources/gtksourceview/5.3/gtksourceview-5.3.2.tar.xz",
-          "sha256": "af7736e2ee3cdbc1013090e8caf35fb89d65cf41c9c399cac5d8992d955ded30"
-        }
-      ]
-    },
     {
       "name": "Commit",
       "buildsystem": "meson",


### PR DESCRIPTION
The latest GNOME runtime includes recent enough versions of both
libadwaita and gtksourceview, so we can drop all bundled modules.
