### PR TITLE
Add mnemonics to buttons

### DIFF
--- a/src/scm.js
+++ b/src/scm.js
@@ -2,16 +2,16 @@ import wrapbody from "./wrap.js";
 import { gettext as _ } from "gettext";
 
 const actions = {
-  commit: _("Commit"),
-  hg: _("Commit"),
-  merge: _("Merge"),
-  tag: _("Tag"),
-  "add -p": _("Add"),
-  rebase: _("Rebase"),
+  commit: _("_Commit"),
+  hg: _("_Commit"),
+  merge: _("_Merge"),
+  tag: _("_Tag"),
+  "add -p": _("A_dd"),
+  rebase: _("_Rebase"),
 };
 
 export function parse(text, type) {
-  const action = actions[type] || _("Save");
+  const action = actions[type] || _("_Save");
 
   if (type === "config") {
     return {

--- a/src/window.ui
+++ b/src/window.ui
@@ -16,7 +16,8 @@
             <property name="show_end_title_buttons">false</property>
             <child>
               <object class="GtkButton">
-                <property name="label" translatable="yes">Abort</property>
+                <property name="label" translatable="yes">_Abort</property>
+                <property name="use-underline">true</property>
                 <property name="action-name">win.cancel</property>
                 <property
                   name="tooltip-text"
@@ -26,7 +27,8 @@
             </child>
             <child type="end">
               <object class="GtkButton" id="button_save">
-                <property name="label" translatable="yes">Save</property>
+                <property name="label" translatable="yes">_Save</property>
+                <property name="use-underline">true</property>
                 <property name="sensitive">false</property>
                 <property name="action-name">win.save</property>
                 <property


### PR DESCRIPTION
Despite having some shortcuts for committing and aborting the current
commit message, I personally use mnemonics all the time when available,
so it's nice to have some available to feel right at home, since I then
don't need to remember what shortcut it is exactly: I can just use Alt
and look at the button :)