### PR TITLE
Fix (flatpak) build

### DIFF
--- a/re.sonny.Commit.json
+++ b/re.sonny.Commit.json
@@ -13,6 +13,19 @@
   ],
   "modules": [
     {
+      "name": "blueprint",
+      "buildsystem": "meson",
+      "builddir": true,
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler.git",
+          "tag": "v0.2.0",
+          "commit": "87cedc2c7e48b01dc1b07aef937e2fe02111b18c"
+        }
+      ]
+    },
+    {
       "name": "Commit",
       "buildsystem": "meson",
       "builddir": true,

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,10 +2,20 @@ pkgdatadir = join_paths(get_option('datadir'), meson.project_name())
 gnome = import('gnome')
 
 gjspack = find_program('../troll/gjspack/bin/gjspack')
-run_command(gjspack, '--appid=' + meson.project_name(), '--no-executable', 'src/main.js', '--potfiles', 'po/POTFILES', 'src', check: true)
-
-install_data('re.sonny.Commit.gresource',
-  install_dir: pkgdatadir
+gresource = custom_target(meson.project_name() + '.gresource',
+  input: ['main.js', '../po/POTFILES'],
+  output: meson.project_name() + '.gresource',
+  command: [
+    gjspack,
+    '--appid=' + meson.project_name(),
+    '--resource-root', meson.project_source_root(),
+    '--no-executable',
+    '@INPUT0@',
+    '--potfiles', '@INPUT1@',
+    '@OUTDIR@',
+  ],
+  install: true,
+  install_dir: pkgdatadir,
 )
 
 bin_conf = configuration_data()


### PR DESCRIPTION
The build now depends on blueprint, which isn't provided by the runtime, so bundle it.

In addition, the gjspack invocation makes wrong assumptions about how the command is launched, which causes it to fail. Use the newly added --resource-root flag to fix that as well. (Depends on https://github.com/sonnyp/troll/pull/10)
