### PR TITLE
Update Sergey Bugaev link

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Many thanks to its original author [Aral Balkan](https://ar.al) of [Small Techno
 ### Contributors
 
 - [Aral Balkan](https://ar.al)
-- [Sergey Bugaev](https://mastodon.technology/@bugaevc)
+- [Sergey Bugaev](https://floss.social/@bugaevc)
 - [Sonny Piers](https://github.com/sonnyp)
 - [Tobias Bernard](https://tobiasbernard.com/)
 - [Christopher Davis](https://social.libre.fi/brainblasted)

--- a/src/about.js
+++ b/src/about.js
@@ -26,7 +26,7 @@ export default function About({ application, version }) {
     // "John Doe <john@example.com>",
     // or
     // "John Doe https://john.com",
-    "Sergey Bugaev https://mastodon.technology/@bugaevc",
+    "Sergey Bugaev https://floss.social/@bugaevc",
     "Christopher Davis https://social.libre.fi/brainblasted",
     "axtlos https://github.com/axtloss",
   ]);


### PR DESCRIPTION
It's very nice of you to keep me in the contributors list 😃

Unfortunately [mastodon.technology has been shut down](https://ashfurrow.com/blog/mastodon-technology-shutdown/) 😢, so the link is dead. I'm [on floss.social now](https://floss.social/@bugaevc), so update the link to point there.