### PR TITLE
general: Improve tooltips

### DIFF
--- a/src/about.js
+++ b/src/about.js
@@ -29,6 +29,7 @@ export default function About({ application, version }) {
     "Sergey Bugaev https://floss.social/@bugaevc",
     "Christopher Davis https://social.libre.fi/brainblasted",
     "axtlos https://github.com/axtloss",
+    "Felipe Kinoshita https://mastodon.social/@fkinoshita",
   ]);
   dialog.present();
 

--- a/src/welcome.blp
+++ b/src/welcome.blp
@@ -15,6 +15,7 @@ Adw.ApplicationWindow window {
       MenuButton menubutton {
         menu-model: app-menu;
         icon-name: "open-menu-symbolic";
+        tooltip-text: _("Main Menu");
       }
     }
 

--- a/src/window.blp
+++ b/src/window.blp
@@ -18,7 +18,7 @@ Adw.ApplicationWindow window {
         label: _("_Abort");
         use-underline: true;
         action-name: "win.cancel";
-        tooltip-text: _("Cancel and dismiss");
+        tooltip-text: _("Cancel and Dismiss");
       }
 
       [end]
@@ -27,7 +27,7 @@ Adw.ApplicationWindow window {
         use-underline: true;
         sensitive: false;
         action-name: "win.save";
-        tooltip-text: _("Save and confirm");
+        tooltip-text: _("Save and Confirm");
 
         styles [
           "suggested-action",
@@ -41,6 +41,7 @@ Adw.ApplicationWindow window {
         primary: true;
         icon-name: "open-menu-symbolic";
         menu-model: app-menu;
+        tooltip-text: _("Main Menu");
         halign: end;
         valign: end;
         margin-end: 12;


### PR DESCRIPTION
This commit adds tooltips to primary menus, both on the welcome window and on the commit editor.

It also makes existing tooltips follow header capitalization as recommended by the HIG.

See: https://developer.gnome.org/hig/patterns/feedback/tooltips.html